### PR TITLE
Actor collision detection

### DIFF
--- a/src/actor.c
+++ b/src/actor.c
@@ -2,24 +2,18 @@
 #include "entity.h"
 #include "sprite.h"
 
-qActor_t* qActor_Create( sfVector2f mapPos, sfVector2f mapHitBoxSize, float maxVelocity,
-                         qSpriteTexture_t* spriteTexture, sfVector2f spriteOffset, float spriteFrameSeconds )
+void qActor_Setup( qActor_t* actor, sfVector2f mapPos, sfVector2f mapHitBoxSize, float maxVelocity,
+                   qSpriteTexture_t* spriteTexture, sfVector2f spriteOffset, float spriteFrameSeconds )
 {
-   qActor_t* actor = (qActor_t*)qAlloc( sizeof( qActor_t ), sfTrue );
-
    actor->entity = qEntity_Create( mapPos, mapHitBoxSize, maxVelocity );
    actor->sprite = qSprite_Create( spriteTexture, spriteFrameSeconds );
    actor->spriteOffset = spriteOffset;
-
-   return actor;
 }
 
-void qActor_Destroy( qActor_t* actor )
+void qActor_Cleanup( qActor_t* actor )
 {
    qSprite_Destroy( actor->sprite );
    qEntity_Destroy( actor->entity );
-
-   qFree( actor, sizeof( qActor_t ), sfTrue );
 }
 
 void qActor_SetDirection( qActor_t* actor, qDirection_t direction )

--- a/src/actor.h
+++ b/src/actor.h
@@ -17,9 +17,9 @@ typedef struct qActor_t
 }
 qActor_t;
 
-qActor_t* qActor_Create( sfVector2f mapPos, sfVector2f mapHitBoxSize, float maxVelocity,
-                         qSpriteTexture_t* spriteTexture, sfVector2f spriteOffset, float spriteFrameSeconds );
-void qActor_Destroy( qActor_t* actor );
+void qActor_Setup( qActor_t* actor, sfVector2f mapPos, sfVector2f mapHitBoxSize, float maxVelocity,
+                   qSpriteTexture_t* spriteTexture, sfVector2f spriteOffset, float spriteFrameSeconds );
+void qActor_Cleanup( qActor_t* actor );
 void qActor_SetDirection( qActor_t* actor, qDirection_t direction );
 void qActor_Tic( qActor_t* actor, qClock_t* clock );
 

--- a/src/common.h
+++ b/src/common.h
@@ -32,6 +32,8 @@
 
 #define FAST_VELOCITY   500.0f
 
+#define MAX_ACTORS      256
+
 #define TOGGLE_BOOL( x ) x = x ? sfFalse : sfTrue;
 
 // globals

--- a/src/game.c
+++ b/src/game.c
@@ -57,6 +57,7 @@ qGame_t* qGame_Create()
    qActor_Setup( &( game->actors[1] ), actor2Pos, actorHitBoxSize, 150.0f, &( game->renderer->renderObjects->spriteTextures[0] ), actorSpriteOffset, 0.15f );
    qActor_Setup( &( game->actors[2] ), actor3Pos, actorHitBoxSize, 80.0f, &( game->renderer->renderObjects->spriteTextures[0] ), actorSpriteOffset, 0.15f );
    game->controllingActor = &( game->actors[0] );
+   game->controllingActorIndex = 0;
 
    game->showDiagnostics = sfFalse;
    game->cheatNoClip = sfFalse;
@@ -126,4 +127,16 @@ void qGame_ShowDebugMessage( qGame_t* game, const char* msg )
    snprintf( state->msgBuffer, state->msgBufferLen, "%s", msg );
    state->isVisible = sfTrue;
    state->elapsedSeconds = 0;
+}
+
+void qGame_SwitchControllingActor( qGame_t* game )
+{
+   game->controllingActorIndex++;
+
+   if ( game->controllingActorIndex >= game->actorCount )
+   {
+      game->controllingActorIndex = 0;
+   }
+
+   game->controllingActor = &( game->actors[game->controllingActorIndex] );
 }

--- a/src/game.c
+++ b/src/game.c
@@ -18,7 +18,9 @@ qGame_t* qGame_Create()
 {
    sfVector2u mapTileCount = { 56, 56 };
    uint32_t i, tileIndex;
-   sfVector2f actorPos = { 896, 896 };
+   sfVector2f actor1Pos = { 896, 896 };
+   sfVector2f actor2Pos = { 64, 64 };
+   sfVector2f actor3Pos = { 256, 832 };
    sfVector2f actorHitBoxSize = { 26, 16 };
    sfVector2f actorSpriteOffset = { -3, -16 };
 
@@ -49,9 +51,11 @@ qGame_t* qGame_Create()
       game->map->tiles[tileIndex].isPassable = sfFalse;
    }
 
-   // just one actor for now
-   game->actors = qActor_Create( actorPos, actorHitBoxSize, 100.0f, &( game->renderer->renderObjects->spriteTextures[0] ), actorSpriteOffset, 0.15f );
-   game->actorCount = 1;
+   game->actors = (qActor_t*)qAlloc( sizeof( qActor_t ) * 3, sfTrue );
+   game->actorCount = 3;
+   qActor_Setup( &( game->actors[0] ), actor1Pos, actorHitBoxSize, 100.0f, &( game->renderer->renderObjects->spriteTextures[0] ), actorSpriteOffset, 0.15f );
+   qActor_Setup( &( game->actors[1] ), actor2Pos, actorHitBoxSize, 150.0f, &( game->renderer->renderObjects->spriteTextures[0] ), actorSpriteOffset, 0.15f );
+   qActor_Setup( &( game->actors[2] ), actor3Pos, actorHitBoxSize, 80.0f, &( game->renderer->renderObjects->spriteTextures[0] ), actorSpriteOffset, 0.15f );
    game->controllingActor = &( game->actors[0] );
 
    game->showDiagnostics = sfFalse;
@@ -67,8 +71,10 @@ void qGame_Destroy( qGame_t* game )
 
    for ( i = 0; i < game->actorCount; i++ )
    {
-      qActor_Destroy( &( game->actors[i] ) );
+      qActor_Cleanup( &( game->actors[i] ) );
    }
+
+   qFree( game->actors, sizeof( qActor_t ) * game->actorCount, sfTrue );
 
    qMap_Destroy( game->map );
    qPhysics_Destroy( game->physics );

--- a/src/game.c
+++ b/src/game.c
@@ -58,6 +58,7 @@ qGame_t* qGame_Create()
    qActor_Setup( &( game->actors[2] ), actor3Pos, actorHitBoxSize, 80.0f, &( game->renderer->renderObjects->spriteTextures[0] ), actorSpriteOffset, 0.15f );
    game->controllingActor = &( game->actors[0] );
    game->controllingActorIndex = 0;
+   qRenderer_ChangeActors( game );
 
    game->showDiagnostics = sfFalse;
    game->cheatNoClip = sfFalse;

--- a/src/game.h
+++ b/src/game.h
@@ -25,6 +25,7 @@ typedef struct qGame_t
    uint32_t actorCount;
    qActor_t* controllingActor;
    uint32_t controllingActorIndex;
+   sfBool actorsMoved;
 
    sfBool showDiagnostics;
    sfBool cheatNoClip;

--- a/src/game.h
+++ b/src/game.h
@@ -25,7 +25,6 @@ typedef struct qGame_t
    uint32_t actorCount;
    qActor_t* controllingActor;
    uint32_t controllingActorIndex;
-   sfBool actorsMoved;
 
    sfBool showDiagnostics;
    sfBool cheatNoClip;

--- a/src/game.h
+++ b/src/game.h
@@ -24,6 +24,7 @@ typedef struct qGame_t
    qActor_t* actors;
    uint32_t actorCount;
    qActor_t* controllingActor;
+   uint32_t controllingActorIndex;
 
    sfBool showDiagnostics;
    sfBool cheatNoClip;
@@ -36,5 +37,6 @@ void qGame_Destroy( qGame_t* game );
 void qGame_Run( qGame_t* game );
 void qGame_Close( qGame_t* game );
 void qGame_ShowDebugMessage( qGame_t* game, const char* msg );
+void qGame_SwitchControllingActor( qGame_t* game );
 
 #endif // GAME_H

--- a/src/input_handler.c
+++ b/src/input_handler.c
@@ -48,6 +48,11 @@ void qInputHandler_HandleInput( qGame_t* game )
       }
    }
 
+   if ( qInputState_WasKeyPressed( game->inputState, sfKeyTab ) )
+   {
+      qGame_SwitchControllingActor( game );
+   }
+
    qInputHandler_HandleMapInput( game );
 }
 

--- a/src/math_util.c
+++ b/src/math_util.c
@@ -1,0 +1,16 @@
+#include "math_util.h"
+
+sfBool qMathUtil_RectsOverlap( float l1x, float l1y, float r1x, float r1y, float l2x, float l2y, float r2x, float r2y )
+{
+   if ( l1x > r2x || l2x > r1x )
+   {
+      return sfFalse;
+   }
+
+   if ( r1y > l2y || r2y > l1y )
+   {
+      return sfFalse;
+   }
+
+   return sfTrue;
+}

--- a/src/math_util.c
+++ b/src/math_util.c
@@ -1,5 +1,10 @@
 #include "math_util.h"
 
+sfBool qMathUtil_Vector2fEqual( sfVector2f* v1, sfVector2f* v2 )
+{
+   return v1->x == v2->x && v1->y == v2->y;
+}
+
 sfBool qMathUtil_RectsOverlap( float l1x, float t1y, float r1x, float b1y, float l2x, float t2y, float r2x, float b2y )
 {
    if ( l1x > r2x || l2x > r1x )

--- a/src/math_util.c
+++ b/src/math_util.c
@@ -1,13 +1,13 @@
 #include "math_util.h"
 
-sfBool qMathUtil_RectsOverlap( float l1x, float l1y, float r1x, float r1y, float l2x, float l2y, float r2x, float r2y )
+sfBool qMathUtil_RectsOverlap( float l1x, float t1y, float r1x, float b1y, float l2x, float t2y, float r2x, float b2y )
 {
    if ( l1x > r2x || l2x > r1x )
    {
       return sfFalse;
    }
 
-   if ( r1y > l2y || r2y > l1y )
+   if ( t1y > b2y || t2y > b1y )
    {
       return sfFalse;
    }

--- a/src/math_util.h
+++ b/src/math_util.h
@@ -1,0 +1,8 @@
+#if !defined( MATH_UTIL_H )
+#define MATH_UTIL_H
+
+#include "common.h"
+
+sfBool qMathUtil_RectsOverlap( float l1x, float l1y, float r1x, float r1y, float l2x, float l2y, float r2x, float r2y );
+
+#endif // MATH_UTIL_H

--- a/src/math_util.h
+++ b/src/math_util.h
@@ -3,6 +3,6 @@
 
 #include "common.h"
 
-sfBool qMathUtil_RectsOverlap( float l1x, float l1y, float r1x, float r1y, float l2x, float l2y, float r2x, float r2y );
+sfBool qMathUtil_RectsOverlap( float l1x, float t1y, float r1x, float b1y, float l2x, float t2y, float r2x, float b2y );
 
 #endif // MATH_UTIL_H

--- a/src/math_util.h
+++ b/src/math_util.h
@@ -3,6 +3,7 @@
 
 #include "common.h"
 
+sfBool qMathUtil_Vector2fEqual( sfVector2f* v1, sfVector2f* v2 );
 sfBool qMathUtil_RectsOverlap( float l1x, float t1y, float r1x, float b1y, float l2x, float t2y, float r2x, float b2y );
 
 #endif // MATH_UTIL_H

--- a/src/physics.c
+++ b/src/physics.c
@@ -31,6 +31,8 @@ void qPhysics_Tic( qGame_t* game )
 {
    uint32_t i;
 
+   game->actorsMoved = sfFalse;
+
    for ( i = 0; i < game->actorCount; i++ )
    {
       qPhysics_TicActor( game, &( game->actors[i] ) );
@@ -71,6 +73,11 @@ void qPhysics_TicActor( qGame_t* game, qActor_t* actor )
 
    qPhysics_ClipActorToMapVertical( game, actor, &newPos );
    qPhysics_ClipActorToActors( game, actor, &newPos, sfFalse );
+
+   if ( qMathUtil_Vector2fEqual( &( entity->mapPos ), &newPos ) )
+   {
+      game->actorsMoved = sfTrue;
+   }
 
    entity->mapPos = newPos;
    qActor_Tic( actor, game->clock );

--- a/src/physics.c
+++ b/src/physics.c
@@ -169,6 +169,9 @@ static void qPhysics_ClipActorToActors( qGame_t* game, qActor_t* actor, sfVector
    qEntity_t* otherEntity;
    qActor_t* otherActor;
    uint32_t i;
+   float newRightX = newPos->x + entity->mapHitBoxSize.x;
+   float newBottomY = newPos->y + entity->mapHitBoxSize.y;
+   float otherRightX, otherBottomY;
 
    for ( i = 0; i < game->actorCount; i++ )
    {
@@ -180,32 +183,31 @@ static void qPhysics_ClipActorToActors( qGame_t* game, qActor_t* actor, sfVector
       }
 
       otherEntity = otherActor->entity;
+      otherRightX = otherEntity->mapPos.x + otherEntity->mapHitBoxSize.x;
+      otherBottomY = otherEntity->mapPos.y + otherEntity->mapHitBoxSize.y;
 
-      if ( qMathUtil_RectsOverlap( newPos->x, newPos->y,
-                                   newPos->x + entity->mapHitBoxSize.x, newPos->y + entity->mapHitBoxSize.y,
-                                   otherEntity->mapPos.x, otherEntity->mapPos.y,
-                                   otherEntity->mapPos.x + otherEntity->mapHitBoxSize.x, otherEntity->mapPos.y + otherEntity->mapHitBoxSize.y ) )
+      if ( qMathUtil_RectsOverlap( newPos->x, newPos->y, newRightX, newBottomY, otherEntity->mapPos.x, otherEntity->mapPos.y, otherRightX, otherBottomY ) )
       {
-         if ( horizontal && newPos->x >= otherEntity->mapPos.x && newPos->x <= otherEntity->mapPos.x )
+         if ( horizontal )
          {
-            if ( newPos->x < otherEntity->mapPos.x + ( otherEntity->mapHitBoxSize.x / 2 ) )
+            if ( entity->velocity.x > 0 && newRightX >= otherEntity->mapPos.x && newRightX <= otherRightX )
             {
                newPos->x = otherEntity->mapPos.x - entity->mapHitBoxSize.x - COLLISION_PADDING;
             }
-            else
+            else if ( entity->velocity.x < 0 && newPos->x >= otherEntity->mapPos.x && newPos->x <= otherRightX )
             {
-               newPos->x = entity->mapPos.x + entity->mapHitBoxSize.x + COLLISION_PADDING;
+               newPos->x = otherRightX + COLLISION_PADDING;
             }
          }
-         else if ( !horizontal && newPos->y >= otherEntity->mapPos.y && newPos->y <= otherEntity->mapPos.y )
+         else
          {
-            if ( newPos->y < otherEntity->mapPos.y + ( otherEntity->mapHitBoxSize.y / 2 ) )
+            if ( entity->velocity.y > 0 && newBottomY >= otherEntity->mapPos.y && newBottomY <= otherBottomY )
             {
                newPos->y = otherEntity->mapPos.y - entity->mapHitBoxSize.y - COLLISION_PADDING;
             }
-            else
+            else if ( entity->velocity.y < 0 && newPos->y >= otherEntity->mapPos.y && newPos->y <= otherBottomY )
             {
-               newPos->y = entity->mapPos.y + entity->mapHitBoxSize.y + COLLISION_PADDING;
+               newPos->y = otherBottomY + COLLISION_PADDING;
             }
          }
       }

--- a/src/physics.c
+++ b/src/physics.c
@@ -31,7 +31,7 @@ void qPhysics_Tic( qGame_t* game )
 {
    uint32_t i;
 
-   game->actorsMoved = sfFalse;
+   game->physics->actorMoved = sfFalse;
 
    for ( i = 0; i < game->actorCount; i++ )
    {
@@ -76,7 +76,7 @@ void qPhysics_TicActor( qGame_t* game, qActor_t* actor )
 
    if ( qMathUtil_Vector2fEqual( &( entity->mapPos ), &newPos ) )
    {
-      game->actorsMoved = sfTrue;
+      game->physics->actorMoved = sfTrue;
    }
 
    entity->mapPos = newPos;

--- a/src/physics.h
+++ b/src/physics.h
@@ -8,6 +8,7 @@ typedef struct qGame_t qGame_t;
 typedef struct qPhysics_t
 {
    uint32_t entityMapTileCache;
+   sfBool actorMoved;
 }
 qPhysics_t;
 

--- a/src/renderer.c
+++ b/src/renderer.c
@@ -9,6 +9,7 @@
 #include "actor.h"
 #include "entity.h"
 #include "sprite.h"
+#include "physics.h"
 
 static void qRenderer_DrawDiagnostics( qGame_t* game );
 static void qRenderer_DrawDebugBar( qGame_t* game );
@@ -254,7 +255,7 @@ static void qRenderer_DrawActors( qGame_t* game )
    sfVector2f spritePos;
    uint32_t i;
 
-   if ( game->actorsMoved )
+   if ( game->physics->actorMoved )
    {
       qRenderer_OrderActors( game );
    }

--- a/src/renderer.c
+++ b/src/renderer.c
@@ -15,6 +15,7 @@ static void qRenderer_DrawDebugBar( qGame_t* game );
 static void qRenderer_SetMapView( qGame_t* game );
 static void qRenderer_DrawMap( qGame_t* game );
 static void qRenderer_DrawActors( qGame_t* game );
+static void qRenderer_OrderActors( qGame_t* game );
 
 qRenderer_t* qRenderer_Create()
 {
@@ -47,6 +48,20 @@ void qRenderer_Destroy( qRenderer_t* renderer )
    qFree( renderer, sizeof( qRenderer_t ), sfTrue );
 }
 
+void qRenderer_ChangeActors( qGame_t* game )
+{
+   uint32_t i;
+   qActor_t* actor;
+
+   for ( i = 0; i < game->actorCount; i++ )
+   {
+      actor = &( game->actors[i] );
+      game->renderer->orderedActors[i] = actor;
+   }
+
+   qRenderer_OrderActors( game );
+}
+
 void qRenderer_Render( qGame_t* game )
 {
    qWindow_DrawRectangleShape( game->window, game->renderer->windowBackgroundRect );
@@ -63,6 +78,19 @@ void qRenderer_Render( qGame_t* game )
    }
 
    qWindow_Display( game->window );
+}
+
+int qRenderer_ActorCmp( const void* a, const void* b )
+{
+   qActor_t* actorA = *(qActor_t**)a;
+   qActor_t* actorB = *(qActor_t**)b;
+
+   return ( actorA->entity->mapPos.y > actorB->entity->mapPos.y );
+}
+
+static void qRenderer_OrderActors( qGame_t* game )
+{
+   qsort( game->renderer->orderedActors, game->actorCount, sizeof( qActor_t* ), qRenderer_ActorCmp );
 }
 
 static void qRenderer_DrawDiagnostics( qGame_t* game )
@@ -226,9 +254,14 @@ static void qRenderer_DrawActors( qGame_t* game )
    sfVector2f spritePos;
    uint32_t i;
 
+   if ( game->actorsMoved )
+   {
+      qRenderer_OrderActors( game );
+   }
+
    for ( i = 0; i < game->actorCount; i++ )
    {
-      actor = &( game->actors[i] );
+      actor = renderer->orderedActors[i];
 
       spritePos.x = ( renderer->mapViewPadding.x > 0 )
          ? ( actor->entity->mapPos.x + actor->spriteOffset.x + renderer->mapViewPadding.x ) * GRAPHICS_SCALE

--- a/src/renderer.h
+++ b/src/renderer.h
@@ -6,6 +6,7 @@
 typedef struct qRenderObjects_t qRenderObjects_t;
 typedef struct qRenderStates_t qRenderStates_t;
 typedef struct qGame_t qGame_t;
+typedef struct qActor_t qActor_t;
 
 typedef struct qRenderer_t
 {
@@ -19,11 +20,14 @@ typedef struct qRenderer_t
    sfVector2f mapTilePixelOffset;
    sfVector2u mapViewStart;
    sfVector2u mapViewEnd;
+
+   qActor_t* orderedActors[MAX_ACTORS];
 }
 qRenderer_t;
 
 qRenderer_t* qRenderer_Create();
 void qRenderer_Destroy( qRenderer_t* renderer );
+void qRenderer_ChangeActors( qGame_t* game );
 void qRenderer_Render( qGame_t* game );
 
 #endif // RENDERER_H

--- a/win/FinalQuest.vcxproj
+++ b/win/FinalQuest.vcxproj
@@ -99,6 +99,7 @@ xcopy "$(SolutionDir)..\src\resources" "$(OutDir)\resources\" /S /Y</Command>
     <ClInclude Include="..\src\input_handler.h" />
     <ClInclude Include="..\src\input_state.h" />
     <ClInclude Include="..\src\map.h" />
+    <ClInclude Include="..\src\math_util.h" />
     <ClInclude Include="..\src\physics.h" />
     <ClInclude Include="..\src\random.h" />
     <ClInclude Include="..\src\renderer.h" />
@@ -120,6 +121,7 @@ xcopy "$(SolutionDir)..\src\resources" "$(OutDir)\resources\" /S /Y</Command>
     <ClCompile Include="..\src\input_state.c" />
     <ClCompile Include="..\src\main.c" />
     <ClCompile Include="..\src\map.c" />
+    <ClCompile Include="..\src\math_util.c" />
     <ClCompile Include="..\src\physics.c" />
     <ClCompile Include="..\src\random.c" />
     <ClCompile Include="..\src\renderer.c" />

--- a/win/FinalQuest.vcxproj.filters
+++ b/win/FinalQuest.vcxproj.filters
@@ -52,6 +52,12 @@
     <ClCompile Include="..\src\sprite_texture.c">
       <Filter>Source Files</Filter>
     </ClCompile>
+    <ClCompile Include="..\src\math_util.c">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\src\physics.c">
+      <Filter>Source Files</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="..\src\clock.h">
@@ -106,6 +112,12 @@
       <Filter>Header Files</Filter>
     </ClInclude>
     <ClInclude Include="..\src\sprite_texture.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\src\math_util.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\src\physics.h">
       <Filter>Header Files</Filter>
     </ClInclude>
   </ItemGroup>


### PR DESCRIPTION
## Overview

This is a pretty rudimentary system where we check if an actor is moving in a certain direction, and detect collisions with other actors in that direction. It doesn't move the actor it collides with, and also doesn't check actors that aren't currently moving. It also uses list of actors sorted by y-position to draw to the screen, so the z-order should always be correct.

I ran into a couple heap corruption errors when debugging this, and I still have no idea where they're coming from. Something to watch out for in the future.