### PR TITLE
Added battles and screen fades

### DIFF
--- a/src/common.h
+++ b/src/common.h
@@ -10,7 +10,7 @@
 #include "strings.h"
 
 #define STRLEN_DEFAULT              512
-#define STRLEN_SHORT                32
+#define STRLEN_SHORT                64
 
 #define LOG_FILENAME                "log.txt"
 
@@ -34,6 +34,8 @@
 
 #define CHEAT_NOCLIP                "fqclip"
 #define CHEAT_FAST                  "fqfast"
+#define CHEAT_ENCOUNTER             "fqfight"
+#define CHEAT_NOENCOUNTERS          "fqinvis"
 #define CHEAT_CLEAR                 "fqclear"
 
 #define FAST_VELOCITY               500.0f

--- a/src/enums.h
+++ b/src/enums.h
@@ -7,7 +7,9 @@ typedef enum qGameState_t
    qGameState_MapMenu,
    qGameState_FadeMapToBattle,
    qGameState_FadeBattleIn,
-   qGameState_Battle
+   qGameState_Battle,
+   qGameState_FadeBattleOut,
+   qGameState_FadeBattleToMap
 }
 qGameState_t;
 

--- a/src/enums.h
+++ b/src/enums.h
@@ -5,6 +5,8 @@ typedef enum qGameState_t
 {
    qGameState_Map = 0,
    qGameState_MapMenu,
+   qGameState_FadeMapToBattle,
+   qGameState_FadeBattleIn,
    qGameState_Battle
 }
 qGameState_t;

--- a/src/enums.h
+++ b/src/enums.h
@@ -4,7 +4,8 @@
 typedef enum qGameState_t
 {
    qGameState_Map = 0,
-   qGameState_MapMenu
+   qGameState_MapMenu,
+   qGameState_Battle
 }
 qGameState_t;
 

--- a/src/game.c
+++ b/src/game.c
@@ -73,6 +73,7 @@ qGame_t* qGame_Create()
    game->showDiagnostics = sfFalse;
    game->cheatNoClip = sfFalse;
    game->cheatFast = sfFalse;
+   game->cheatNoEncounters = sfFalse;
 
    return game;
 }
@@ -183,11 +184,11 @@ void qGame_ExecuteMenuCommand( qGame_t* game, qMenuCommand_t command )
    }
 }
 
-void qGame_RollEncounter( qGame_t* game, uint32_t mapTileIndex )
+void qGame_RollEncounter( qGame_t* game, uint32_t mapTileIndex, sfBool force )
 {
    qMapTile_t* tile = &( game->map->tiles[mapTileIndex] );
 
-   if ( tile->encounterRate > 0 && qRandom_Percent() <= tile->encounterRate )
+   if ( force || ( !game->cheatNoEncounters && tile->encounterRate > 0 && qRandom_Percent() <= tile->encounterRate ) )
    {
       qGame_SetState( game, qGameState_Battle );
    }

--- a/src/game.c
+++ b/src/game.c
@@ -173,6 +173,9 @@ void qGame_SetState( qGame_t* game, qGameState_t state )
       case qGameState_FadeMapToBattle:
          qRenderStates_StartScreenFade( game->renderer->renderStates->screenFade, sfTrue, sfTrue, sfTrue, &qGame_ScreenFadeComplete );
          break;
+      case qGameState_FadeBattleOut:
+         qRenderStates_StartScreenFade( game->renderer->renderStates->screenFade, sfTrue, sfTrue, sfFalse, &qGame_ScreenFadeComplete );
+         break;
    }
 
    game->state = state;
@@ -210,10 +213,17 @@ static void qGame_ScreenFadeComplete( qGame_t* game )
    {
       case qGameState_FadeMapToBattle:
          qGame_SetState( game, qGameState_FadeBattleIn );
-         qRenderStates_StartScreenFade( game->renderer->renderStates->screenFade, sfFalse, sfFalse, sfTrue,&qGame_ScreenFadeComplete );
+         qRenderStates_StartScreenFade( game->renderer->renderStates->screenFade, sfFalse, sfFalse, sfTrue, &qGame_ScreenFadeComplete );
          break;
       case qGameState_FadeBattleIn:
          qGame_SetState( game, qGameState_Battle );
+         break;
+      case qGameState_FadeBattleOut:
+         qGame_SetState( game, qGameState_FadeBattleToMap );
+         qRenderStates_StartScreenFade( game->renderer->renderStates->screenFade, sfFalse, sfFalse, sfFalse, &qGame_ScreenFadeComplete );
+         break;
+      case qGameState_FadeBattleToMap:
+         qGame_SetState( game, qGameState_Map );
          break;
    }
 }

--- a/src/game.h
+++ b/src/game.h
@@ -47,5 +47,6 @@ void qGame_ShowDebugMessage( qGame_t* game, const char* msg );
 void qGame_SwitchControllingActor( qGame_t* game );
 void qGame_SetState( qGame_t* game, qGameState_t state );
 void qGame_ExecuteMenuCommand( qGame_t* game, qMenuCommand_t command );
+void qGame_RollEncounter( qGame_t* game, uint32_t mapTileIndex );
 
 #endif // GAME_H

--- a/src/game.h
+++ b/src/game.h
@@ -36,6 +36,7 @@ typedef struct qGame_t
    sfBool showDiagnostics;
    sfBool cheatNoClip;
    sfBool cheatFast;
+   sfBool cheatNoEncounters;
 }
 qGame_t;
 
@@ -47,6 +48,6 @@ void qGame_ShowDebugMessage( qGame_t* game, const char* msg );
 void qGame_SwitchControllingActor( qGame_t* game );
 void qGame_SetState( qGame_t* game, qGameState_t state );
 void qGame_ExecuteMenuCommand( qGame_t* game, qMenuCommand_t command );
-void qGame_RollEncounter( qGame_t* game, uint32_t mapTileIndex );
+void qGame_RollEncounter( qGame_t* game, uint32_t mapTileIndex, sfBool force );
 
 #endif // GAME_H

--- a/src/input_handler.c
+++ b/src/input_handler.c
@@ -60,7 +60,7 @@ void qInputHandler_HandleInput( qGame_t* game )
       case qGameState_Battle:
          if ( game->inputState->keyWasPressed )
          {
-            qGame_SetState( game, qGameState_Map );
+            qGame_SetState( game, qGameState_FadeBattleOut );
          }
          break;
    }

--- a/src/input_handler.c
+++ b/src/input_handler.c
@@ -53,6 +53,12 @@ void qInputHandler_HandleInput( qGame_t* game )
       case qGameState_MapMenu:
          qInputHandler_HandleMapMenuInput( game );
          break;
+      case qGameState_Battle:
+         if ( game->inputState->keyWasPressed )
+         {
+            qGame_SetState( game, qGameState_Map );
+         }
+         break;
    }
 }
 

--- a/src/map.h
+++ b/src/map.h
@@ -7,6 +7,7 @@ typedef struct qMapTile_t
 {
    uint32_t textureIndex;
    sfBool isPassable;
+   uint8_t encounterRate;
 }
 qMapTile_t;
 

--- a/src/physics.c
+++ b/src/physics.c
@@ -18,7 +18,7 @@ qPhysics_t* qPhysics_Create()
 {
    qPhysics_t* physics = (qPhysics_t*)qAlloc( sizeof( qPhysics_t ), sfTrue );
 
-   physics->entityMapTileCache = 0;
+   physics->actorTileCache = 0;
 
    return physics;
 }
@@ -36,6 +36,14 @@ void qPhysics_Tic( qGame_t* game )
          qPhysics_TicActors( game );
          break;
    }
+}
+
+void qPhysics_ResetActorTileCache( qGame_t* game )
+{
+   qEntity_t* entity = game->controllingActor->entity;
+   sfVector2f entityCenterPos = { entity->mapPos.x + entity->mapHitBoxSize.x, entity->mapPos.y + entity->mapHitBoxSize.y };
+
+   game->physics->actorTileCache = qMap_TileIndexFromPos( game->map, entityCenterPos );
 }
 
 static void qPhysics_TicActors( qGame_t* game )
@@ -97,11 +105,16 @@ void qPhysics_TicActor( qGame_t* game, qActor_t* actor )
 
    entityCenterPos.x = entity->mapPos.x + ( entity->mapHitBoxSize.x / 2 );
    entityCenterPos.y = entity->mapPos.y + ( entity->mapHitBoxSize.y / 2 );
-   newTileIndex = qMap_TileIndexFromPos( game->map, entityCenterPos );
 
-   if ( newTileIndex != game->physics->entityMapTileCache )
+   if ( actor == game->controllingActor )
    {
-      game->physics->entityMapTileCache = newTileIndex;
+      newTileIndex = qMap_TileIndexFromPos( game->map, entityCenterPos );
+
+      if ( newTileIndex != game->physics->actorTileCache )
+      {
+         game->physics->actorTileCache = newTileIndex;
+         qGame_RollEncounter( game, newTileIndex );
+      }
    }
 }
 

--- a/src/physics.c
+++ b/src/physics.c
@@ -113,7 +113,7 @@ void qPhysics_TicActor( qGame_t* game, qActor_t* actor )
       if ( newTileIndex != game->physics->actorTileCache )
       {
          game->physics->actorTileCache = newTileIndex;
-         qGame_RollEncounter( game, newTileIndex );
+         qGame_RollEncounter( game, newTileIndex, sfFalse );
       }
    }
 }

--- a/src/physics.h
+++ b/src/physics.h
@@ -7,7 +7,7 @@ typedef struct qGame_t qGame_t;
 
 typedef struct qPhysics_t
 {
-   uint32_t entityMapTileCache;
+   uint32_t actorTileCache;
    sfBool actorMoved;
 }
 qPhysics_t;
@@ -15,5 +15,6 @@ qPhysics_t;
 qPhysics_t* qPhysics_Create();
 void qPhysics_Destroy( qPhysics_t* physics );
 void qPhysics_Tic( qGame_t* game );
+void qPhysics_ResetActorTileCache( qGame_t* game );
 
 #endif // PHYSICS_H

--- a/src/render_objects.c
+++ b/src/render_objects.c
@@ -5,10 +5,12 @@ static qDiagnosticsRenderObjects_t* qRenderObjects_CreateDiagnostics();
 static qDebugBarRenderObjects_t* qRenderObjects_CreateDebugBar();
 static qMapRenderObjects_t* qRenderObjects_CreateMap();
 static qMapMenuRenderObjects_t* qRenderObjects_CreateMapMenu();
+static qScreenFadeRenderObjects_t* qRenderObjects_CreateScreenFade();
 static void qRenderObjects_DestroyDiagnostics( qDiagnosticsRenderObjects_t* objects );
 static void qRenderObjects_DestroyDebugBar( qDebugBarRenderObjects_t* objects );
 static void qRenderObjects_DestroyMap( qMapRenderObjects_t* objects );
 static void qRenderObjects_DestroyMapMenu( qMapMenuRenderObjects_t* objects );
+static void qRenderObjects_DestroyScreenFade( qScreenFadeRenderObjects_t* objects );
 static void gmRenderObjects_BuildDialogBackground( sfConvexShape* shape,
                                                    float x, float y,
                                                    float w, float h,
@@ -22,6 +24,7 @@ qRenderObjects_t* qRenderObjects_Create()
    renderObjects->debugBar = qRenderObjects_CreateDebugBar();
    renderObjects->map = qRenderObjects_CreateMap();
    renderObjects->mapMenu = qRenderObjects_CreateMapMenu();
+   renderObjects->screenFade = qRenderObjects_CreateScreenFade();
 
    renderObjects->spriteTextureCount = 3;
    renderObjects->spriteTextures = (qSpriteTexture_t*)qAlloc( sizeof( qSpriteTexture_t ) * renderObjects->spriteTextureCount, sfTrue );
@@ -121,6 +124,25 @@ static qMapMenuRenderObjects_t* qRenderObjects_CreateMapMenu()
    return objects;
 }
 
+static qScreenFadeRenderObjects_t* qRenderObjects_CreateScreenFade()
+{
+   sfVector2f v = { 0, 0 };
+
+   qScreenFadeRenderObjects_t* objects = (qScreenFadeRenderObjects_t*)qAlloc( sizeof( qScreenFadeRenderObjects_t ), sfTrue );
+
+   objects->screenRect = qsfRectangleShape_Create();
+
+   sfRectangleShape_setPosition( objects->screenRect, v );
+   v.x = WINDOW_WIDTH;
+   v.y = WINDOW_HEIGHT;
+   sfRectangleShape_setSize( objects->screenRect, v );
+
+   objects->lightColor = sfWhite;
+   objects->darkColor = sfBlack;
+
+   return objects;
+}
+
 void qRenderObjects_Destroy( qRenderObjects_t* objects )
 {
    uint32_t i;
@@ -132,6 +154,7 @@ void qRenderObjects_Destroy( qRenderObjects_t* objects )
 
    qFree( objects->spriteTextures, sizeof( qSpriteTexture_t ) * objects->spriteTextureCount, sfTrue );
 
+   qRenderObjects_DestroyScreenFade( objects->screenFade );
    qRenderObjects_DestroyMapMenu( objects->mapMenu );
    qRenderObjects_DestroyMap( objects->map );
    qRenderObjects_DestroyDebugBar( objects->debugBar );
@@ -173,6 +196,13 @@ static void qRenderObjects_DestroyMapMenu( qMapMenuRenderObjects_t* objects )
    qsfConvexShape_Destroy( objects->backgroundShape );
 
    qFree( objects, sizeof( qMapMenuRenderObjects_t ), sfTrue );
+}
+
+static void qRenderObjects_DestroyScreenFade( qScreenFadeRenderObjects_t* objects )
+{
+   qsfRectangleShape_Destroy( objects->screenRect );
+
+   qFree( objects, sizeof( qScreenFadeRenderObjects_t ), sfTrue );
 }
 
 static void gmRenderObjects_BuildDialogBackground( sfConvexShape* shape,

--- a/src/render_objects.h
+++ b/src/render_objects.h
@@ -42,12 +42,21 @@ typedef struct qMapMenuRenderObjects_t
 }
 qMapMenuRenderObjects_t;
 
+typedef struct qScreenFadeRenderObjects_t
+{
+   sfRectangleShape* screenRect;
+   sfColor lightColor;
+   sfColor darkColor;
+}
+qScreenFadeRenderObjects_t;
+
 typedef struct qRenderObjects_t
 {
    qDiagnosticsRenderObjects_t* diagnostics;
    qDebugBarRenderObjects_t* debugBar;
    qMapRenderObjects_t* map;
    qMapMenuRenderObjects_t* mapMenu;
+   qScreenFadeRenderObjects_t* screenFade;
 
    qSpriteTexture_t* spriteTextures;
    uint32_t spriteTextureCount;

--- a/src/render_states.c
+++ b/src/render_states.c
@@ -137,7 +137,11 @@ void qRenderStates_ResetScreenFade( qScreenFadeRenderState_t* state )
    state->elapsedSeconds = 0;
 }
 
-void qRenderStates_StartScreenFade( qScreenFadeRenderState_t* state, sfBool fadeOut, sfBool pause, sfBool isLightColor )
+void qRenderStates_StartScreenFade( qScreenFadeRenderState_t* state,
+                                    sfBool fadeOut,
+                                    sfBool pause,
+                                    sfBool isLightColor,
+                                    void (*fadeCompleteFnc)(qGame_t*) )
 {
    qRenderStates_ResetScreenFade( state );
    state->fadeOut = fadeOut;
@@ -145,6 +149,7 @@ void qRenderStates_StartScreenFade( qScreenFadeRenderState_t* state, sfBool fade
    state->isLightColor = isLightColor;
    state->isRunning = sfTrue;
    state->isFading = sfTrue;
+   state->fadeCompleteFnc = fadeCompleteFnc;
 }
 
 static void qRenderStates_TicScreenFade( qGame_t* game )
@@ -172,6 +177,7 @@ static void qRenderStates_TicScreenFade( qGame_t* game )
          else
          {
             state->isRunning = sfFalse;
+            ( *state->fadeCompleteFnc )( game );
          }
       }
    }
@@ -181,6 +187,7 @@ static void qRenderStates_TicScreenFade( qGame_t* game )
       {
          state->isPausing = sfFalse;
          state->isRunning = sfFalse;
+         ( *state->fadeCompleteFnc )( game );
       }
    }
 }

--- a/src/render_states.c
+++ b/src/render_states.c
@@ -5,9 +5,12 @@
 
 static qDebugBarRenderState_t* qRenderStates_CreateDebugBar();
 static qMenuRenderState_t* qRenderStates_CreateMenu();
+static qScreenFadeRenderState_t* qRenderStates_CreateScreenFade();
 static void qRenderStates_DestroyDebugBar( qDebugBarRenderState_t* state );
 static void qRenderStates_DestroyMenu( qMenuRenderState_t* state );
+static void qRenderStates_DestroyScreenFade( qScreenFadeRenderState_t* state );
 static void qRenderStates_TicMenu( qGame_t* game );
+static void qRenderStates_TicScreenFade( qGame_t* game );
 
 qRenderStates_t* qRenderStates_Create()
 {
@@ -15,6 +18,7 @@ qRenderStates_t* qRenderStates_Create()
 
    states->debugBar = qRenderStates_CreateDebugBar();
    states->menu = qRenderStates_CreateMenu();
+   states->screenFade = qRenderStates_CreateScreenFade();
 
    return states;
 }
@@ -42,8 +46,20 @@ static qMenuRenderState_t* qRenderStates_CreateMenu()
    return state;
 }
 
+static qScreenFadeRenderState_t* qRenderStates_CreateScreenFade()
+{
+   qScreenFadeRenderState_t* state = (qScreenFadeRenderState_t*)qAlloc( sizeof( qScreenFadeRenderState_t ), sfTrue );
+
+   state->fadeSeconds = 0.4f;
+   state->pauseSeconds = 0.1f;
+   qRenderStates_ResetScreenFade( state );
+
+   return state;
+}
+
 void qRenderStates_Destroy( qRenderStates_t* states )
 {
+   qRenderStates_DestroyScreenFade( states->screenFade );
    qRenderStates_DestroyDebugBar( states->debugBar );
    qRenderStates_DestroyMenu( states->menu );
 
@@ -61,6 +77,11 @@ static void qRenderStates_DestroyMenu( qMenuRenderState_t* state )
    qFree( state, sizeof( qMenuRenderState_t ), sfTrue );
 }
 
+static void qRenderStates_DestroyScreenFade( qScreenFadeRenderState_t* state )
+{
+   qFree( state, sizeof( qScreenFadeRenderState_t ), sfTrue );
+}
+
 void qRenderStates_Tic( qGame_t* game )
 {
    qRenderStates_t* states = game->renderer->renderStates;
@@ -76,7 +97,14 @@ void qRenderStates_Tic( qGame_t* game )
       }
    }
 
-   qRenderStates_TicMenu( game );
+   if ( states->screenFade->isRunning )
+   {
+      qRenderStates_TicScreenFade( game );
+   }
+   else
+   {
+      qRenderStates_TicMenu( game );
+   }
 }
 
 void qRenderStates_ResetMenu( qMenuRenderState_t* state )
@@ -97,6 +125,62 @@ static void qRenderStates_TicMenu( qGame_t* game )
       {
          TOGGLE_BOOL( states->menu->showCarat );
          states->menu->caratElapsedSeconds -= states->menu->caratBlinkSeconds;
+      }
+   }
+}
+
+void qRenderStates_ResetScreenFade( qScreenFadeRenderState_t* state )
+{
+   state->isRunning = sfFalse;
+   state->isFading = sfFalse;
+   state->isPausing = sfFalse;
+   state->elapsedSeconds = 0;
+}
+
+void qRenderStates_StartScreenFade( qScreenFadeRenderState_t* state, sfBool fadeOut, sfBool pause, sfBool isLightColor )
+{
+   qRenderStates_ResetScreenFade( state );
+   state->fadeOut = fadeOut;
+   state->pause = pause;
+   state->isLightColor = isLightColor;
+   state->isRunning = sfTrue;
+   state->isFading = sfTrue;
+}
+
+static void qRenderStates_TicScreenFade( qGame_t* game )
+{
+   qScreenFadeRenderState_t* state = game->renderer->renderStates->screenFade;
+
+   if ( !state->isRunning )
+   {
+      return;
+   }
+
+   state->elapsedSeconds += game->clock->frameDeltaSeconds;
+
+   if ( state->isFading )
+   {
+      if ( state->elapsedSeconds > state->fadeSeconds )
+      {
+         state->isFading = sfFalse;
+
+         if ( state->pause )
+         {
+            state->isPausing = sfTrue;
+            state->elapsedSeconds = 0;
+         }
+         else
+         {
+            state->isRunning = sfFalse;
+         }
+      }
+   }
+   else if ( state->isPausing )
+   {
+      if ( state->elapsedSeconds > state->pauseSeconds )
+      {
+         state->isPausing = sfFalse;
+         state->isRunning = sfFalse;
       }
    }
 }

--- a/src/render_states.h
+++ b/src/render_states.h
@@ -23,10 +23,25 @@ typedef struct qMenuRenderState_t
 }
 qMenuRenderState_t;
 
+typedef struct qScreenFadeRenderState_t
+{
+   sfBool isRunning;
+   sfBool isFading;
+   sfBool isPausing;
+   sfBool fadeOut;
+   sfBool pause;
+   sfBool isLightColor;
+   float fadeSeconds;
+   float pauseSeconds;
+   float elapsedSeconds;
+}
+qScreenFadeRenderState_t;
+
 typedef struct qRenderStates_t
 {
    qDebugBarRenderState_t* debugBar;
    qMenuRenderState_t* menu;
+   qScreenFadeRenderState_t* screenFade;
 }
 qRenderStates_t;
 
@@ -34,5 +49,7 @@ qRenderStates_t* qRenderStates_Create();
 void qRenderStates_Destroy( qRenderStates_t* states );
 void qRenderStates_Tic( qGame_t* game );
 void qRenderStates_ResetMenu( qMenuRenderState_t* state );
+void qRenderStates_ResetScreenFade( qScreenFadeRenderState_t* state );
+void qRenderStates_StartScreenFade( qScreenFadeRenderState_t* state, sfBool fadeOut, sfBool pause, sfBool isLightColor );
 
 #endif // RENDER_STATES_H

--- a/src/render_states.h
+++ b/src/render_states.h
@@ -34,6 +34,7 @@ typedef struct qScreenFadeRenderState_t
    float fadeSeconds;
    float pauseSeconds;
    float elapsedSeconds;
+   void (*fadeCompleteFnc)( qGame_t* );
 }
 qScreenFadeRenderState_t;
 
@@ -50,6 +51,10 @@ void qRenderStates_Destroy( qRenderStates_t* states );
 void qRenderStates_Tic( qGame_t* game );
 void qRenderStates_ResetMenu( qMenuRenderState_t* state );
 void qRenderStates_ResetScreenFade( qScreenFadeRenderState_t* state );
-void qRenderStates_StartScreenFade( qScreenFadeRenderState_t* state, sfBool fadeOut, sfBool pause, sfBool isLightColor );
+void qRenderStates_StartScreenFade( qScreenFadeRenderState_t* state,
+                                    sfBool fadeOut,
+                                    sfBool pause,
+                                    sfBool isLightColor,
+                                    void (*fadeCompleteFnc)(qGame_t*) );
 
 #endif // RENDER_STATES_H

--- a/src/renderer.c
+++ b/src/renderer.c
@@ -14,6 +14,7 @@
 
 static void qRenderer_DrawDiagnostics( qGame_t* game );
 static void qRenderer_DrawDebugBar( qGame_t* game );
+static void qRenderer_DrawScreenFade( qGame_t* game );
 static void qRenderer_SetMapView( qGame_t* game );
 static void qRenderer_DrawMap( qGame_t* game );
 static void qRenderer_DrawMapMenu( qGame_t* game );
@@ -72,6 +73,7 @@ void qRenderer_Render( qGame_t* game )
    switch ( game->state )
    {
       case qGameState_Map:
+      case qGameState_FadeMapToBattle:
          qRenderer_SetMapView( game );
          qRenderer_DrawMap( game );
          qRenderer_DrawActors( game );
@@ -84,6 +86,7 @@ void qRenderer_Render( qGame_t* game )
          break;
    }
 
+   qRenderer_DrawScreenFade( game );
    qRenderer_DrawDebugBar( game );
 
    if ( game->showDiagnostics )
@@ -152,6 +155,37 @@ static void qRenderer_DrawDebugBar( qGame_t* game )
 
       qWindow_DrawRectangleShape( game->window, objects->backgroundRect );
       qWindow_DrawText( game->window, objects->text );
+   }
+}
+
+static void qRenderer_DrawScreenFade( qGame_t* game )
+{
+   float screenFadePercentage;
+   qRenderer_t* renderer = game->renderer;
+   qScreenFadeRenderState_t* screenFadeState = renderer->renderStates->screenFade;
+   qScreenFadeRenderObjects_t* screenFadeObjects = renderer->renderObjects->screenFade;
+
+   if ( screenFadeState->isRunning )
+   {
+      screenFadePercentage = screenFadeState->isPausing ? 1.0f : screenFadeState->elapsedSeconds / screenFadeState->fadeSeconds;
+
+      if ( !screenFadeState->fadeOut )
+      {
+         screenFadePercentage = 1.0f - screenFadePercentage;
+      }
+
+      if ( screenFadeState->isLightColor )
+      {
+         screenFadeObjects->lightColor.a = (sfUint8)( 255 * screenFadePercentage );
+         sfRectangleShape_setFillColor( screenFadeObjects->screenRect, screenFadeObjects->lightColor );
+      }
+      else
+      {
+         screenFadeObjects->darkColor.a = (sfUint8)( 255 * screenFadePercentage );
+         sfRectangleShape_setFillColor( screenFadeObjects->screenRect, screenFadeObjects->darkColor );
+      }
+
+      qWindow_DrawRectangleShape( game->window, screenFadeObjects->screenRect );
    }
 }
 

--- a/src/renderer.c
+++ b/src/renderer.c
@@ -74,6 +74,7 @@ void qRenderer_Render( qGame_t* game )
    {
       case qGameState_Map:
       case qGameState_FadeMapToBattle:
+      case qGameState_FadeBattleToMap:
          qRenderer_SetMapView( game );
          qRenderer_DrawMap( game );
          qRenderer_DrawActors( game );

--- a/src/strings.h
+++ b/src/strings.h
@@ -41,6 +41,8 @@
 
 #define STR_CHEAT_NOCLIPFORMATTER         "Toggled no-clip mode %s"
 #define STR_CHEAT_FASTFORMATTER           "Toggled fast mode %s"
+#define STR_CHEAT_ENCOUNTER               "Forced an encounter"
+#define STR_CHEAT_NOENCOUNTERSFORMATTER   "Toggled no-encounters mode %s"
 #define STR_CHEAT_CLEARED                 "Cleared all cheats"
 
 #endif // STRINGS_H


### PR DESCRIPTION
## Overview

This adds map tile encounter rates and battles (along with the screen fading in and out between states). Nothing at all happens in the battle itself yet, but I like the way this works better than in CGameBase, it's more deliberate in the use of screen fade callbacks, instead of always checking states. I think I might be using that kind of structure in more things from now on.